### PR TITLE
Adding optional length parameter to `toByteArray()`

### DIFF
--- a/data/src/main/java/no/nordicsemi/kotlin/data/byteArrayOperations.kt
+++ b/data/src/main/java/no/nordicsemi/kotlin/data/byteArrayOperations.kt
@@ -38,21 +38,43 @@ import java.nio.ByteOrder
 import kotlin.math.pow
 
 /**
- * Converts an Int to a byte array using the given endianness.
+ * Converts an `Int` to a byte array using the given endianness.
+ *
+ * The optional [length] parameter allows you to specify the actual length of the field,
+ * to convert 8-bit, 16-bit or 24-bit integers stored in an `Int` to a byte array.
+ * @param length The length of the field, in bytes, within the range of 1-[Int.SIZE_BYTES] with
+ * default value equal to [Int.SIZE_BYTES] bytes.
  * @param order The byte order, default is [ByteOrder.BIG_ENDIAN].
+ * @throws IllegalArgumentException If the length is not within the range of 1 to [Int.SIZE_BYTES].
  */
-fun Int.toByteArray(order: ByteOrder = ByteOrder.BIG_ENDIAN) = when (order) {
-    ByteOrder.BIG_ENDIAN -> ByteArray(4) { (this ushr (24 - it * 8)).toByte() }
-    else ->                 ByteArray(4) { (this ushr (it * 8)).toByte() }
+fun Int.toByteArray(order: ByteOrder = ByteOrder.BIG_ENDIAN, length: Int = Int.SIZE_BYTES): ByteArray {
+    require(length > 0 && length <= Int.SIZE_BYTES) {
+        "Length must be between 1 and ${Int.SIZE_BYTES} bytes, got $length"
+    }
+    return when (order) {
+        ByteOrder.BIG_ENDIAN -> ByteArray(length) { (this ushr (((length - 1) * 8) - it * 8)).toByte() }
+        else ->                 ByteArray(length) { (this ushr (it * 8)).toByte() }
+    }
 }
 
 /**
- * Converts an UInt to a byte array using the given endianness.
+ * Converts an `UInt` to a byte array using the given endianness.
+ *
+ * The optional [length] parameter allows you to specify the actual length of the field,
+ * to convert 8-bit, 16-bit or 24-bit integers stored in an `UInt` to a byte array.
+ * @param length The length of the field, in bytes, within the range of 1-[UInt.SIZE_BYTES] with
+ * default value equal to [UInt.SIZE_BYTES] bytes.
  * @param order The byte order, default is [ByteOrder.BIG_ENDIAN].
+ * @throws IllegalArgumentException If the length is not within the range of 1 to [UInt.SIZE_BYTES].
  */
-fun UInt.toByteArray(order: ByteOrder = ByteOrder.BIG_ENDIAN) = when (order) {
-    ByteOrder.BIG_ENDIAN -> ByteArray(4) { (this shr (24 - it * 8)).toByte() }
-    else ->                 ByteArray(4) { (this shr (it * 8)).toByte() }
+fun UInt.toByteArray(order: ByteOrder = ByteOrder.BIG_ENDIAN, length: Int = UInt.SIZE_BYTES): ByteArray {
+    require(length > 0 && length <= UInt.SIZE_BYTES) {
+        "Length must be between 1 and ${UInt.SIZE_BYTES} bytes, got $length"
+    }
+    return when (order) {
+        ByteOrder.BIG_ENDIAN -> ByteArray(length) { (this shr (((length - 1) * 8) - it * 8)).toByte() }
+        else -> ByteArray(length) { (this shr (it * 8)).toByte() }
+    }
 }
 
 /**

--- a/data/src/test/java/no/nordicsemi/kotlin/data/ByteArrayOperationsTest.kt
+++ b/data/src/test/java/no/nordicsemi/kotlin/data/ByteArrayOperationsTest.kt
@@ -41,7 +41,7 @@ internal class ByteArrayOperationsTest {
 
     @Test
     fun intToByteArray() {
-        val value: Int = -2023406815
+        val value: Int = -2023406815 // 0x87_65_43_21
         val bigEndian = value.toByteArray(ByteOrder.BIG_ENDIAN)
         val littleEndian = value.toByteArray(ByteOrder.LITTLE_ENDIAN)
         assertContentEquals(byteArrayOf(0x87.toByte(), 0x65, 0x43, 0x21), bigEndian)
@@ -50,11 +50,33 @@ internal class ByteArrayOperationsTest {
 
     @Test
     fun uIntToByteArray() {
-        val value = 2271560481u
+        val value = 2271560481u // 0x87_65_43_21
         val bigEndian = value.toByteArray(ByteOrder.BIG_ENDIAN)
         val littleEndian = value.toByteArray(ByteOrder.LITTLE_ENDIAN)
         assertContentEquals(byteArrayOf(0x87.toByte(), 0x65, 0x43, 0x21), bigEndian)
         assertContentEquals(byteArrayOf(0x21, 0x43, 0x65, 0x87.toByte()), littleEndian)
+    }
+
+    @Test
+    fun uInt24ToByteArray() {
+        val value = 0xF23456u
+        val bigEndian = value.toByteArray(ByteOrder.BIG_ENDIAN, length = IntFormat.INT24.length)
+        val littleEndian = value.toByteArray(ByteOrder.LITTLE_ENDIAN, length = IntFormat.INT24.length)
+        assertEquals(bigEndian.size, 3)
+        assertEquals(littleEndian.size, 3)
+        assertContentEquals(byteArrayOf(0xF2.toByte(), 0x34, 0x56), bigEndian)
+        assertContentEquals(byteArrayOf(0x56, 0x34, 0xF2.toByte()), littleEndian)
+    }
+
+    @Test
+    fun int16ToByteArray() {
+        val value = -6000 // 0xE890
+        val bigEndian = value.toByteArray(ByteOrder.BIG_ENDIAN, length = IntFormat.INT16.length)
+        val littleEndian = value.toByteArray(ByteOrder.LITTLE_ENDIAN, length = IntFormat.INT16.length)
+        assertEquals(bigEndian.size, 2)
+        assertEquals(littleEndian.size, 2)
+        assertContentEquals(byteArrayOf(0xE8.toByte(), 0x90.toByte()), bigEndian)
+        assertContentEquals(byteArrayOf(0x90.toByte(), 0xE8.toByte()), littleEndian)
     }
 
     @Test


### PR DESCRIPTION
This PR allows converting integers shorter than 4 bytes to `ByteArray`:

```kotlin
val param = 0xFEDCBA
val paramBytes = param.toByteArray(order = ByteOrder.LITTLE_ENDIAN, length = IntFormat.INT24.length)
println(paramBytes) // "[0xBA, 0xDC, 0xFE]"
```